### PR TITLE
Added static TryParse/Create methods to strongly-typed IDs.

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,1 +1,1 @@
-next-version: 8.0.0
+next-version: 8.2.0

--- a/src/Fluxera.StronglyTypedId/IStronglyTypedId.cs
+++ b/src/Fluxera.StronglyTypedId/IStronglyTypedId.cs
@@ -9,12 +9,29 @@
 	/// <typeparam name="TStronglyTypedId"></typeparam>
 	/// <typeparam name="TKey"></typeparam>
 	[PublicAPI]
-	public interface IStronglyTypedId<TStronglyTypedId, out TKey> : IComparable<TStronglyTypedId>, IEquatable<TStronglyTypedId>
+	public interface IStronglyTypedId<TStronglyTypedId, TKey> : IComparable<TStronglyTypedId>, IEquatable<TStronglyTypedId>
 		where TKey : notnull, IComparable
 	{
 		/// <summary>
 		///     Gets the underlying value of the strongly-typed ID.
 		/// </summary>
 		public TKey Value { get; }
+
+#if NET7_0_OR_GREATER
+		/// <summary>
+		///		Parses the <see cref="TStronglyTypedId"/> from the given string value.
+		/// </summary>
+		/// <param name="value"></param>
+		/// <param name="id"></param>
+		/// <returns></returns>
+		static abstract bool TryParse(string value, out TStronglyTypedId id);
+
+		/// <summary>
+		///		Creates a new instance of the <see cref="TStronglyTypedId"/> with the given value.
+		/// </summary>
+		/// <param name="value"></param>
+		/// <returns></returns>
+		static abstract TStronglyTypedId Create(TKey value);
+#endif
 	}
 }

--- a/src/Fluxera.StronglyTypedId/TypeExtensions.cs
+++ b/src/Fluxera.StronglyTypedId/TypeExtensions.cs
@@ -15,17 +15,8 @@
 		{
 			type = type.UnwrapNullableType();
 			return
-				(type == typeof(sbyte)) ||
-				(type == typeof(byte)) ||
-				(type == typeof(short)) ||
-				(type == typeof(ushort)) ||
-				(type == typeof(int)) ||
-				(type == typeof(uint)) ||
-				(type == typeof(long)) ||
-				(type == typeof(ulong)) ||
-				(type == typeof(decimal)) ||
-				(type == typeof(float)) ||
-				(type == typeof(double));
+				type == typeof(int) ||
+				type == typeof(long);
 		}
 
 		/// <summary>

--- a/tests/Fluxera.StronglyTypedId.UnitTests/CreationTests.cs
+++ b/tests/Fluxera.StronglyTypedId.UnitTests/CreationTests.cs
@@ -62,5 +62,35 @@
 
 			action.Should().Throw<ArgumentException>();
 		}
+
+#if NET7_0_OR_GREATER
+		[Test]
+		public void ShouldCreateStringId()
+		{
+			StringId id = StringId.Create("1234");
+
+			id.Should().NotBeNull();
+			id.Value.Should().Be("1234");
+		}
+
+		[Test]
+		public void ShouldCreateIntegerId()
+		{
+			IntegerId id = IntegerId.Create(1234);
+
+			id.Should().NotBeNull();
+			id.Value.Should().Be(1234);
+		}
+
+		[Test]
+		public void ShouldCreateGuidId()
+		{
+			Guid value = Guid.NewGuid();
+			GuidId id = GuidId.Create(value);
+
+			id.Should().NotBeNull();
+			id.Value.Should().Be(value);
+		}
+#endif
 	}
 }

--- a/tests/Fluxera.StronglyTypedId.UnitTests/TryParseTests.cs
+++ b/tests/Fluxera.StronglyTypedId.UnitTests/TryParseTests.cs
@@ -1,0 +1,82 @@
+﻿#if NET7_0_OR_GREATER
+namespace Fluxera.StronglyTypedId.UnitTests
+{
+	using System;
+	using FluentAssertions;
+	using Fluxera.StronglyTypedId.UnitTests.Model;
+	using NUnit.Framework;
+
+	[TestFixture]
+	public class TryParseTests
+	{
+		[Test]
+		public void ShouldParseStringId()
+		{
+			bool success = StringId.TryParse("1234asdf", out StringId id);
+
+			success.Should().BeTrue();
+			id.Should().NotBeNull();
+			id.Value.Should().Be("1234asdf");
+		}
+
+		[Test]
+		[TestCase(null)]
+		[TestCase("")]
+		[TestCase("  ")]
+		public void ShouldNotParseStringId(string value)
+		{
+			bool success = StringId.TryParse(value, out StringId id);
+
+			success.Should().BeFalse();
+			id.Should().BeNull();
+		}
+
+		[Test]
+		public void ShouldParseNumericId()
+		{
+			bool success = IntegerId.TryParse("123", out IntegerId id);
+
+			success.Should().BeTrue();
+			id.Should().NotBeNull();
+			id.Value.Should().Be(123);
+		}
+
+		[Test]
+		[TestCase(null)]
+		[TestCase("")]
+		[TestCase("  ")]
+		[TestCase("asdf")]
+		[TestCase("1243-asdf")]
+		public void ShouldNotParseNumericId(string value)
+		{
+			bool success = IntegerId.TryParse(value, out IntegerId id);
+
+			success.Should().BeFalse();
+			id.Should().BeNull();
+		}
+
+		[Test]
+		public void ShouldParseGuidId()
+		{
+			bool success = GuidId.TryParse("0f445ea8c8884f47ab75bf7127a7f00d", out GuidId id);
+
+			success.Should().BeTrue();
+			id.Should().NotBeNull();
+			id.Value.Should().Be(Guid.Parse("0f445ea8c8884f47ab75bf7127a7f00d"));
+		}
+
+		[Test]
+		[TestCase(null)]
+		[TestCase("")]
+		[TestCase("  ")]
+		[TestCase("0f445ea8f47f7127a7f00d")]
+		public void ShouldNotParseGuidId(string value)
+		{
+			bool success = GuidId.TryParse(value, out GuidId id);
+
+			success.Should().BeFalse();
+			id.Should().BeNull();
+		}
+	}
+}
+#endif


### PR DESCRIPTION
This feature is only available in .NET 7 or higher.